### PR TITLE
Fix command mode binding taken by Windows OS

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,7 @@ U (dvorak)   activate <i>Insert Mode</i></pre>
         <action id="ErgoKeysCommandMode" class="com.github.amibiz.ergokeys.CommandModeAction" text="Command Mode"
                 description="Activate Command Mode">
             <keyboard-shortcut keymap="$default" first-keystroke="alt SPACE"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="shift SPACE"/>
         </action>
         <action id="ErgoKeysInsertMode" class="com.github.amibiz.ergokeys.InsertModeAction" text="Insert Mode"
                 description="Activate Insert Mode"/>


### PR DESCRIPTION
Fixes #9

- bind Shift + Space -> activate command mode