### PR TITLE
enable plugin for idea 2022.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 intellij {
     plugins = ['java']
-    version = '2021.3'
+    version = '2022.2'
 }
 
 patchPluginXml {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.github.amibiz'
-version '1.13.213'
+version '1.13.214'
 
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
@@ -24,5 +24,5 @@ intellij {
 
 patchPluginXml {
     sinceBuild = '212'
-    untilBuild = '213.*'
+    untilBuild = '222.*'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.3.0'
+    id 'org.jetbrains.intellij' version '1.7.0'
 }
 
 group 'com.github.amibiz'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.github.amibiz'
-version '1.13.214'
+version '1.13.222'
 
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.7.0'
+    id 'org.jetbrains.intellij' version '1.8.1'
 }
 
 group 'com.github.amibiz'

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,9 +23,9 @@ U (dvorak)   activate <i>Insert Mode</i></pre>
     <idea-version since-build="212"/>
 
     <change-notes><![CDATA[
-    <b>1.13.213</b><br/>
+    <b>1.13.222</b><br/>
     <ul>
-        <li>update IntelliJ support to 213.* and forward</li>
+        <li>update IntelliJ support to 222.* and forward</li>
     </ul>
     ]]></change-notes>
 


### PR DESCRIPTION
Hello there,

I just started using IDEA a few weeks ago and I didn't managed to find this plugin available on the marketplace.
I then discovered to be possible to install it manually, but it didn't worked because of the supported version, I'm using IDEA 2022.2.

I'm not familiar with Java and Gradle (actually I'm completely clueless) and for the past weeks I've been thinking I couldn't use the plugin, but I've managed to find my way through the project to update and generate a supported version of the plugin.

I'm not sure I understood the naming being used for versioning, I don't know I should call it `version '1.13.214'` or `version '1.13.222'`.

Let me know if I should adjust something else.

Kind regards, and thanks for the plugin.